### PR TITLE
Add unit test project, add Polygon2d.Contains(Segment2d) method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Folders
+.vs/
+
 # Compiled Object files
 *.slo
 *.lo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,18 +13,16 @@ dotnet_csproj:
 
 build_script:
 - cmd: >-
+    dotnet restore geometry3Sharp.csproj
+
     dotnet restore geometry3Sharp_netstandard.csproj
+
+    dotnet build geometry3Sharp.csproj -c Release
 
     dotnet build geometry3Sharp_netstandard.csproj -c Release
 
-    dotnet build tests/geometry3Sharp.Tests.csproj -c Release
-
     dotnet pack geometry3Sharp_netstandard.csproj -c Release
-test:
-  # only assemblies to test
-  assemblies:
-    only:
-      - tests\bin\Release\netcoreapp2.1\*.dll
+test: on
 artifacts:
 - path: bin\Release\*.nupkg
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,14 +17,15 @@ build_script:
 
     dotnet build tests/geometry3Sharp.Tests.csproj -c Release
 
-    dotnet test tests/geometry3Sharp.Tests.csproj -c Release
-
-    dotnet restore geometry3Sharp_netstandard.csproj 
+    dotnet restore geometry3Sharp_netstandard.csproj
 
     dotnet build geometry3Sharp_netstandard.csproj -c Release
 
     dotnet pack geometry3Sharp_netstandard.csproj -c Release
-test: on
+test: 
+  assemblies:
+    only:
+      - tests\bin\Release\netcoreapp2.1\geometry3Sharp.Tests.dll
 artifacts:
 - path: bin\Release\*.nupkg
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,10 @@ build_script:
     dotnet restore geometry3Sharp_netstandard.csproj
 
     dotnet build geometry3Sharp_netstandard.csproj -c Release
+    dotnet build tests/geometry3Sharp.Tests.csproj -c Release
 
     dotnet pack geometry3Sharp_netstandard.csproj -c Release
-test: off
+test: on
 artifacts:
 - path: bin\Release\*.nupkg
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,11 @@ build_script:
     dotnet build tests/geometry3Sharp.Tests.csproj -c Release
 
     dotnet pack geometry3Sharp_netstandard.csproj -c Release
-test: on
+test:
+  # only assemblies to test
+  assemblies:
+    only:
+      - tests\bin\Release\netcoreapp2.1\*.dll
 artifacts:
 - path: bin\Release\*.nupkg
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ build_script:
     dotnet restore geometry3Sharp_netstandard.csproj
 
     dotnet build geometry3Sharp_netstandard.csproj -c Release
+
     dotnet build tests/geometry3Sharp.Tests.csproj -c Release
 
     dotnet pack geometry3Sharp_netstandard.csproj -c Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,11 @@ dotnet_csproj:
 
 build_script:
 - cmd: >-
-    dotnet restore geometry3Sharp.csproj
+    dotnet restore tests/geometry3Sharp.Tests.csproj
 
     dotnet restore geometry3Sharp_netstandard.csproj
 
-    dotnet build geometry3Sharp.csproj -c Release
+    dotnet build tests/geometry3Sharp.Tests.csproj -c Release
 
     dotnet build geometry3Sharp_netstandard.csproj -c Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,11 @@ build_script:
 - cmd: >-
     dotnet restore tests/geometry3Sharp.Tests.csproj
 
-    dotnet restore geometry3Sharp_netstandard.csproj
-
     dotnet build tests/geometry3Sharp.Tests.csproj -c Release
+
+    dotnet test tests/geometry3Sharp.Tests.csproj -c Release
+
+    dotnet restore geometry3Sharp_netstandard.csproj 
 
     dotnet build geometry3Sharp_netstandard.csproj -c Release
 

--- a/curve/Polygon2d.cs
+++ b/curve/Polygon2d.cs
@@ -333,8 +333,20 @@ namespace g3
 			return true;
 		}
 
+        public bool Contains(Segment2d o)
+        {
+            if (Contains(o.P0 ) == false || Contains(o.P1) == false)
+                return false;
 
-		public bool Intersects(Polygon2d o) {
+            foreach (Segment2d seg in SegmentItr())
+            {
+                if (seg.Intersects(o))
+                    return false;
+            }
+            return true;
+        }
+
+        public bool Intersects(Polygon2d o) {
 			if ( ! this.GetBounds().Intersects( o.GetBounds() ) )
 				return false;
 

--- a/geometry3Sharp.csproj
+++ b/geometry3Sharp.csproj
@@ -333,18 +333,10 @@
     <Compile Include="curve\Hexagon2.cs" />
     <Compile Include="solvers\CholeskyDecomposition.cs" />
     <Compile Include="spatial\Bitmap2.cs" />
-    <Compile Include="tests\curve\Polygon2d.Test.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="interfaces\" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include=".gitignore" />
     <None Include="LICENSE" />

--- a/geometry3Sharp.csproj
+++ b/geometry3Sharp.csproj
@@ -333,10 +333,18 @@
     <Compile Include="curve\Hexagon2.cs" />
     <Compile Include="solvers\CholeskyDecomposition.cs" />
     <Compile Include="spatial\Bitmap2.cs" />
+    <Compile Include="tests\curve\Polygon2d.Test.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="interfaces\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include=".gitignore" />
     <None Include="LICENSE" />

--- a/geometry3Sharp_netstandard.csproj
+++ b/geometry3Sharp_netstandard.csproj
@@ -26,6 +26,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="tests\**" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
 

--- a/tests/curve/Polygon2d.Test.cs
+++ b/tests/curve/Polygon2d.Test.cs
@@ -1,0 +1,150 @@
+using g3;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace geometry3Sharp.Tests
+{
+    [TestClass]
+    public class Polygon2d_ContainsPoint
+    {
+
+        private readonly Polygon2d PolyBase;
+
+        // Constructor
+        public Polygon2d_ContainsPoint()
+        {
+            /* Sets up a polygon with the following shape:
+
+               3 ------------ 2
+               |              |
+               |              |
+               |              |
+               |              |
+               |              |
+               0 ------------ 1
+
+            */
+
+            PolyBase = new Polygon2d( new double[8] {
+                0, 0,
+                6, 0,
+                6, 8,
+                0, 8,
+            });
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsPoint_Inside()
+        {
+            // Act
+            bool actual = PolyBase.Contains(new Vector2d(3, 4));
+
+            // Assert
+            Assert.IsTrue(actual);
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsPoint_Outside()
+        {
+            // Act
+            bool result = PolyBase.Contains(new Vector2d(3, 9));
+
+            // Assert
+            Assert.IsFalse(result); 
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsPoint_OnEdge()
+        {
+            // Act
+            bool result = PolyBase.Contains(new Vector2d(3, 0));
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+    }
+
+    [TestClass]
+    public class Polygon2d_ContainsPolgon
+    {
+
+        private readonly Polygon2d PolyBase;
+
+        // Constructor
+        public Polygon2d_ContainsPolgon()
+        {
+            /* Sets up a polygon with the following shape:
+
+               3 ------------ 2
+                \             |
+                 \            |
+                  4           |
+                 /            |
+                /             |
+               0 ------------ 1
+
+            */
+
+            PolyBase = new Polygon2d(new double[10] {
+                0, 0,
+                6, 0,
+                6, 8,
+                0, 8,
+                2, 4,
+            });
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsPolyon_Inside()
+        {
+            // Arrange
+            Polygon2d PolyOther = new Polygon2d(new double[8] {
+                3, 3,
+                5, 3,
+                5, 7,
+                3, 7,
+            });
+
+            // Act
+            bool result = PolyBase.Contains(PolyOther);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsPolyon_Intersecting()
+        {
+            // Arrange
+            Polygon2d PolyOther = new Polygon2d(new double[8] {
+                3, 3,
+                9, 3,
+                9, 7,
+                3, 7,
+            });
+
+            // Act
+            bool result = PolyBase.Contains(PolyOther);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsPolyon_Outside()
+        {
+            // Arrange
+            Polygon2d PolyOther = new Polygon2d(new double[8] {
+                13, 3,
+                15, 3,
+                15, 7,
+                13, 7,
+            });
+
+            // Act
+            bool result = PolyBase.Contains(PolyOther);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/tests/curve/Polygon2d.Test.cs
+++ b/tests/curve/Polygon2d.Test.cs
@@ -147,4 +147,95 @@ namespace geometry3Sharp.Tests
             Assert.IsFalse(result);
         }
     }
+
+    [TestClass]
+    public class Polygon2d_ContainsSegment
+    {
+
+        private readonly Polygon2d PolyBase;
+
+        // Constructor
+        public Polygon2d_ContainsSegment()
+        {
+            /* Sets up a polygon with the following shape:
+
+               3 ------------ 2
+                \             |
+                 \            |
+                  4           |
+                 /            |
+                /             |
+               0 ------------ 1
+
+            */
+
+            PolyBase = new Polygon2d(new double[10] {
+                0, 0,
+                6, 0,
+                6, 8,
+                0, 8,
+                2, 4,
+            });
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsSegment_Inside()
+        {
+            // Arrange
+            Segment2d Seg = new Segment2d(
+                new Vector2d(3, 3),
+                new Vector2d(5, 3));
+
+            // Act
+            bool result = PolyBase.Contains(Seg);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsSegment_Intersecting()
+        {
+            // Arrange
+            Segment2d Seg = new Segment2d(
+                new Vector2d(3, 3),
+                new Vector2d(9, 3));
+
+            // Act
+            bool result = PolyBase.Contains(Seg);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsSegment_Outside()
+        {
+            // Arrange
+            Segment2d Seg = new Segment2d(
+                new Vector2d(13, 3),
+                new Vector2d(15, 3));
+
+            // Act
+            bool result = PolyBase.Contains(Seg);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void Polygon2d_ContainsSegment_Crossing()
+        {
+            // Arrange
+            Segment2d Seg = new Segment2d(
+                new Vector2d(1, 1),
+                new Vector2d(1, 7));
+
+            // Act
+            bool result = PolyBase.Contains(Seg);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+    }
 }

--- a/tests/geometry3Sharp.Tests.csproj
+++ b/tests/geometry3Sharp.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\geometry3Sharp.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
I added a simple method to `Polygon2d` to check if it contains a `Segment2d`.

Not sure what the testing approach is for gradientspace is, but wanted to make sure I didn't break anything. So, I added a unit test project `geometry3Sharp.Tests` with some coverage for the various `Polygon2d.Contains(...)` overloads. 