### PR TITLE
Deduplicate triangle-triangle intersection code

### DIFF
--- a/intersection/IntrTriangle3Triangle3.cs
+++ b/intersection/IntrTriangle3Triangle3.cs
@@ -149,100 +149,16 @@ namespace g3
             return false;
         }
 
-
-        public bool Test()
-        {
-            // Get edge vectors for triangle0.
-            Vector3dTuple3 E0;
-            E0.V0 = triangle0.V1 - triangle0.V0;
-            E0.V1 = triangle0.V2 - triangle0.V1;
-            E0.V2 = triangle0.V0 - triangle0.V2;
-
-            // Get normal vector of triangle0.
-            Vector3d N0 = E0[0].UnitCross(E0[1]);
-
-            // Project triangle1 onto normal line of triangle0, test for separation.
-            double N0dT0V0 = N0.Dot(triangle0.V0);
-            double min1, max1;
-            ProjectOntoAxis(ref triangle1, ref N0, out min1, out max1);
-            if (N0dT0V0 < min1 || N0dT0V0 > max1) {
-                return false;
-            }
-
-            // Get edge vectors for triangle1.
-            Vector3dTuple3 E1;
-            E1.V0 = triangle1.V1 - triangle1.V0;
-            E1.V1 = triangle1.V2 - triangle1.V1;
-            E1.V2 = triangle1.V0 - triangle1.V2;
-
-            // Get normal vector of triangle1.
-            Vector3d N1 = E1[0].UnitCross(E1[1]);
-
-            Vector3d dir;
-            double min0, max0;
-            int i0, i1;
-
-            Vector3d N0xN1 = N0.UnitCross(N1);
-            if (N0xN1.Dot(N0xN1) >= MathUtil.ZeroTolerance) {
-                // Triangles are not parallel.
-
-                // Project triangle0 onto normal line of triangle1, test for
-                // separation.
-                double N1dT1V0 = N1.Dot(triangle1.V0);
-                ProjectOntoAxis(ref triangle0, ref N1, out min0, out max0);
-                if (N1dT1V0 < min0 || N1dT1V0 > max0) {
-                    return false;
-                }
-
-                // Directions E0[i0]xE1[i1].
-                for (i1 = 0; i1 < 3; ++i1) {
-                    for (i0 = 0; i0 < 3; ++i0) {
-                        dir = E0[i0].UnitCross(E1[i1]);
-                        ProjectOntoAxis(ref triangle0, ref dir, out min0, out max0);
-                        ProjectOntoAxis(ref triangle1, ref dir, out min1, out max1);
-                        if (max0 < min1 || max1 < min0) {
-                            return false;
-                        }
-                    }
-                }
-
-                // The test query does not know the intersection set.
-                Type = IntersectionType.Unknown;
-            } else { // Triangles are parallel (and, in fact, coplanar).
-                // Directions N0xE0[i0].
-                for (i0 = 0; i0 < 3; ++i0) {
-                    dir = N0.UnitCross(E0[i0]);
-                    ProjectOntoAxis(ref triangle0, ref dir, out min0, out max0);
-                    ProjectOntoAxis(ref triangle1, ref dir, out min1, out max1);
-                    if (max0 < min1 || max1 < min0) {
-                        return false;
-                    }
-                }
-
-                // Directions N1xE1[i1].
-                for (i1 = 0; i1 < 3; ++i1) {
-                    dir = N1.UnitCross(E1[i1]);
-                    ProjectOntoAxis(ref triangle0, ref dir, out min0, out max0);
-                    ProjectOntoAxis(ref triangle1, ref dir, out min1, out max1);
-                    if (max0 < min1 || max1 < min0) {
-                        return false;
-                    }
-                }
-
-                // The test query does not know the intersection set.
-                Type = IntersectionType.Plane;
-            }
-
-            return true;
+        public bool Test() {
+            return Intersects(ref triangle0, ref triangle1, ref Type);
         }
 
+        public static bool Intersects(ref Triangle3d triangle0, ref Triangle3d triangle1) {
+            IntersectionType dummy = 0;
+            return Intersects(ref triangle0, ref triangle1, ref dummy);
+        }
 
-
-
-
-
-
-        public static bool Intersects(ref Triangle3d triangle0, ref Triangle3d triangle1)
+        private static bool Intersects(ref Triangle3d triangle0, ref Triangle3d triangle1, ref IntersectionType type)
         {
             // Get edge vectors for triangle0.
             Vector3dTuple3 E0;
@@ -298,6 +214,8 @@ namespace g3
                     }
                 }
 
+                // The test query does not know the intersection set.
+                type = IntersectionType.Unknown;
             } else { // Triangles are parallel (and, in fact, coplanar).
                 // Directions N0xE0[i0].
                 for (i0 = 0; i0 < 3; ++i0) {
@@ -318,6 +236,8 @@ namespace g3
                         return false;
                     }
                 }
+                // The test query does not know the intersection set.
+                type = IntersectionType.Plane;
             }
 
             return true;


### PR DESCRIPTION
I noticed there were 2 functions with nearly identical code.  Two small differences:

1) the static version was slightly more performant having more `ref` usages, avoiding making copies.  I took this one
1) the non-static one had a side-effect of setting the `Type` which I've maintained.

This is a pure refactor, API and functionality should be the same.