### PR TITLE
Compatibility change for Unity 2017.2 and earlier.

### DIFF
--- a/mesh_generators/MeshGenerators.cs
+++ b/mesh_generators/MeshGenerators.cs
@@ -295,8 +295,10 @@ namespace g3
                 m.uv = ToUnityVector2(uv);
             if (normals != null && WantNormals)
                 m.normals = ToUnityVector3(normals, bFlipLR);
+#if UNITY_2017_3_OR_NEWER
             if ( m.vertexCount > 64000 ||  triangles.Count > 64000 )
                 m.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+#endif
             m.triangles = triangles.array;
             if (bRecalcNormals)
                 m.RecalculateNormals();


### PR DESCRIPTION
This small tweak ensures the library still works with older versions of Unity which don't support 32-bit mesh indexes.