### PR TITLE
Add more snapping utility methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ geometry3Sharp/obj
 geometry3Sharp.csproj.user
 bin
 obj
+.vs
 *.meta

--- a/core/Snapping.cs
+++ b/core/Snapping.cs
@@ -29,5 +29,31 @@ namespace g3
             return fValue;
         }
 
+        private static double SnapToIncrementSigned(double fValue, double fIncrement, bool low)
+        {
+            if (!MathUtil.IsFinite(fValue))
+                return 0;
+            double sign = Math.Sign(fValue);
+            fValue = Math.Abs(fValue);
+            int nInc = (int)(fValue / fIncrement);
+
+            if (low && sign < 0)
+                ++nInc;
+            else if (!low && sign > 0)
+                ++nInc;
+
+            return sign * (double)nInc * fIncrement;
+
+        }
+
+        public static double SnapToIncrementLow(double fValue, double fIncrement)
+        {
+            return SnapToIncrementSigned(fValue, fIncrement, true);
+        }
+
+        public static double SnapToIncrementHigh(double fValue, double fIncrement)
+        {
+            return SnapToIncrementSigned(fValue, fIncrement, false);
+        }
     }
 }

--- a/core/Snapping.cs
+++ b/core/Snapping.cs
@@ -5,17 +5,18 @@ namespace g3
     public class Snapping
     {
 
-        public static double SnapToIncrement(double fValue, double fIncrement)
+        public static double SnapToIncrement(double fValue, double fIncrement, double offset = 0)
         {
             if (!MathUtil.IsFinite(fValue))
                 return 0;
+            fValue -= offset;
             double sign = Math.Sign(fValue);
             fValue = Math.Abs(fValue);
             int nInc = (int)(fValue / fIncrement);
             double fRem = fValue % fIncrement;
             if (fRem > fIncrement / 2)
                 ++nInc;
-            return sign * (double)nInc * fIncrement;
+            return sign * (double)nInc * fIncrement + offset;
         }
 
 
@@ -46,14 +47,14 @@ namespace g3
 
         }
 
-        public static double SnapToIncrementLow(double fValue, double fIncrement)
+        public static double SnapToIncrementLow(double fValue, double fIncrement, double offset=0)
         {
-            return SnapToIncrementSigned(fValue, fIncrement, true);
+            return SnapToIncrementSigned(fValue - offset, fIncrement, true) + offset;
         }
 
-        public static double SnapToIncrementHigh(double fValue, double fIncrement)
+        public static double SnapToIncrementHigh(double fValue, double fIncrement, double offset = 0)
         {
-            return SnapToIncrementSigned(fValue, fIncrement, false);
+            return SnapToIncrementSigned(fValue - offset, fIncrement, false) + offset;
         }
     }
 }


### PR DESCRIPTION
Added a two more simple methods to enforce snapping on the high or low side of the interval.

Also added optional "offset" parameter to allow for using intervals starting from a value other than zero.