### PR TITLE
Distance structs TODO item

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,25 +1,27 @@
 
 [Cleanup]
-- audit for class types that could be structs - distance/, intersection/, etc
-- update implicit API to use double instead of float
-- remove gs namespace
+- [?] audit for class types that could be structs - distance/, intersection/, etc
+	- [x] distance: MeshQueries return null (lines 17, 65, and 123), structs cannot be null. Wrapping in null puts them on heap? returning new() for now. considering out parameter? ResultOrFail? Or a TriangleId struct that checks if it's a valid triangle at creation: public ResultOrFail<TriangleId> DMesh3.CreateTriangleId(int index)?
+	- [ ] intersection
+- [x] update implicit API to use double instead of float
+- [ ] remove gs namespace
 
 [Serialization]
-- add JsonConverter for various core types (Vector2/Vector3/Vector4, Quat, Frame, Transform, ... ?)
-- gltf/glb import/export
-- built-in geometrybuffers support
-- fbx?
+- [?] add JsonConverter for various core types (Vector2/Vector3/Vector4, Quat, Frame, Transform, ... ?)
+- [x] gltf/glb import/export
+- [ ] built-in geometrybuffers support
+- [ ] fbx?
 
 [GeometryCore porting]
-- port PolygonMesh from GeometryCore
-- port MeshTopology from GeometryCore
-- add any missing functions from GeometryCore vector/box/etc types
-- add split-attribute support to DMesh3 (yikes!)
-- port SRGB/Linear color support from GeometryCore
-- add uncompressed Image type (eg see GSImage from GeometryCore)
-- GeometryCore AxisBoxTree2
+- [ ] port PolygonMesh from GeometryCore
+- [x] port MeshTopology from GeometryCore
+- [ ] add any missing functions from GeometryCore vector/box/etc types
+- [ ] add split-attribute support to DMesh3 (yikes!)
+- [ ] port SRGB/Linear color support from GeometryCore
+- [x] add uncompressed Image type (eg see GSImage from GeometryCore)
+- [ ] GeometryCore AxisBoxTree2
 
 
 [Renaming]
-- rename AxisAlignedBox to AxisBox?
-- 
+- [ ] rename AxisAlignedBox to AxisBox?
+- [ ] 

--- a/distance/DistLine2Line2.cs
+++ b/distance/DistLine2Line2.cs
@@ -8,7 +8,7 @@ namespace g3
 	// ported from WildMagic 5 
 	// https://www.geometrictools.com/Downloads/Downloads.html
 
-	public class DistLine2Line2
+	public struct DistLine2Line2
 	{
 		Line2d line1;
 		public Line2d Line

--- a/distance/DistLine2Segment2.cs
+++ b/distance/DistLine2Segment2.cs
@@ -8,7 +8,7 @@ namespace g3
 	// ported from WildMagic 5 
 	// https://www.geometrictools.com/Downloads/Downloads.html
 
-	public class DistLine2Segment2
+	public struct DistLine2Segment2
 	{
 		Line2d line;
 		public Line2d Line

--- a/distance/DistLine3Ray3.cs
+++ b/distance/DistLine3Ray3.cs
@@ -8,14 +8,20 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistLine3Ray3
+    /// <summary>
+    /// Computes distance between a 3D Line and a 3D Ray.
+    /// Converted to struct to minimize heap allocations.
+    /// </summary>
+    public struct DistLine3Ray3
     {
+        // Inputs
         Line3d line;
         public Line3d Line
         {
             get { return line; }
             set { line = value; DistanceSquared = -1.0; }
         }
+
 
         Ray3d ray;
         public Ray3d Ray
@@ -24,6 +30,8 @@ namespace g3
             set { ray = value; DistanceSquared = -1.0; }
         }
 
+
+        // Outputs
         public double DistanceSquared = -1.0;
 
         public Vector3d LineClosest;
@@ -37,10 +45,13 @@ namespace g3
             this.ray = rayIn; this.line = LineIn;
         }
 
+
         static public double MinDistance(Ray3d r, Line3d s)
         {
             return new DistLine3Ray3(r, s).Get();
         }
+
+
         static public double MinDistanceLineParam(Ray3d r, Line3d s)
         {
             return new DistLine3Ray3(r, s).Compute().LineParameter;
@@ -52,6 +63,7 @@ namespace g3
             GetSquared();
             return this;
         }
+
 
         public double Get()
         {

--- a/distance/DistLine3Segment3.cs
+++ b/distance/DistLine3Segment3.cs
@@ -5,11 +5,16 @@ using System.Text;
 
 namespace g3
 {
-	// ported from WildMagic 5 
-	// https://www.geometrictools.com/Downloads/Downloads.html
+    // ported from WildMagic 5 
+    // https://www.geometrictools.com/Downloads/Downloads.html
 
-	public class DistLine3Segment3
+    /// <summary>
+    /// Computes distance between a 3D Line and a 3D Segment.
+    /// Converted to struct to minimize heap allocations.
+    /// </summary>
+    public struct DistLine3Segment3
 	{
+        // Inputs
 		Line3d line;
 		public Line3d Line
 		{
@@ -24,6 +29,7 @@ namespace g3
 			set { segment = value; DistanceSquared = -1.0; }
 		}
 
+        // Outputs
 		public double DistanceSquared = -1.0;
 
 		public Vector3d LineClosest;

--- a/distance/DistLine3Triangle3.cs
+++ b/distance/DistLine3Triangle3.cs
@@ -8,8 +8,13 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistLine3Triangle3
+    /// <summary>
+    /// Computes distance between a 3D Line and a 3D Triangle.
+    /// Converted to struct to minimize heap allocations.
+    /// </summary>
+    public struct DistLine3Triangle3
     {
+        // Input
         Line3d line;
         public Line3d Line
         {
@@ -24,6 +29,7 @@ namespace g3
             set { triangle = value; DistanceSquared = -1.0; }
         }
 
+        // Output
         public double DistanceSquared = -1.0;
 
         public Vector3d LineClosest;

--- a/distance/DistPoint2Box2.cs
+++ b/distance/DistPoint2Box2.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5's DistPoint2Box2
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistPoint2Box2
+    public struct DistPoint2Box2
     {
         Vector2d point;
         public Vector2d Point

--- a/distance/DistPoint2Circle2.cs
+++ b/distance/DistPoint2Circle2.cs
@@ -60,7 +60,8 @@ namespace g3
                 AllCirclePointsEquidistant = false;
             } else {
                 // All circle points are equidistant from P.  Return one of them.
-                CircleClosest = circle.Center + circle.Radius;
+                CircleClosest = circle.Center;
+                CircleClosest.x += circle.Radius;
                 AllCirclePointsEquidistant = true;
             }
 

--- a/distance/DistPoint2Circle2.cs
+++ b/distance/DistPoint2Circle2.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5's  DistPoint3Circle3  (didn't have point2circle2)
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistPoint2Circle2
+    public struct DistPoint2Circle2
     {
         Vector2d point;
         public Vector2d Point

--- a/distance/DistPoint3Circle3.cs
+++ b/distance/DistPoint3Circle3.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistPoint3Circle3
+    public struct DistPoint3Circle3
     {
         Vector3d point;
         public Vector3d Point

--- a/distance/DistPoint3Cylinder3.cs
+++ b/distance/DistPoint3Cylinder3.cs
@@ -15,7 +15,7 @@ namespace g3
     //
     // DistanceSquared is always positive!!
     //
-    public class DistPoint3Cylinder3
+    public struct DistPoint3Cylinder3
     {
         Vector3d point;
         public Vector3d Point

--- a/distance/DistPoint3Triangle3.cs
+++ b/distance/DistPoint3Triangle3.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistPoint3Triangle3
+    public struct DistPoint3Triangle3
     {
         Vector3d point;
         public Vector3d Point

--- a/distance/DistRay3Ray3.cs
+++ b/distance/DistRay3Ray3.cs
@@ -8,7 +8,11 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistRay3Ray3
+    /// <summary>
+    /// Computes distance between two 3D Rays.
+    /// Converted to struct to minimize heap allocations.
+    /// </summary>
+    public struct DistRay3Ray3
     {
         Ray3d ray1;
         public Ray3d Ray1

--- a/distance/DistRay3Segment3.cs
+++ b/distance/DistRay3Segment3.cs
@@ -8,8 +8,9 @@ namespace g3
     /// <summary>
     /// Distance between ray and segment
     /// ported from WildMagic5
+    /// Converted to struct to minimize heap allocations.
     /// </summary>
-    public class DistRay3Segment3
+    public struct DistRay3Segment3
     {
         Ray3d ray;
         public Ray3d Ray

--- a/distance/DistSegment2Segment2.cs
+++ b/distance/DistSegment2Segment2.cs
@@ -8,7 +8,7 @@ namespace g3
 	// ported from WildMagic 5 
 	// https://www.geometrictools.com/Downloads/Downloads.html
 
-	public class DistSegment2Segment2
+	public struct DistSegment2Segment2
 	{
 		Segment2d segment0;
 		public Segment2d Segment1

--- a/distance/DistSegment3Triangle3.cs
+++ b/distance/DistSegment3Triangle3.cs
@@ -8,8 +8,13 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistSegment3Triangle3
+    /// <summary>
+    /// Computes distance between a 3D Segment and a 3D Triangle.
+    /// Converted to struct to minimize heap allocations.
+    /// </summary>
+    public struct DistSegment3Triangle3
     {
+        // Inputs
         Segment3d segment;
         public Segment3d Segment
         {
@@ -24,6 +29,7 @@ namespace g3
             set { triangle = value; DistanceSquared = -1.0; }
         }
 
+        // Outputs
         public double DistanceSquared = -1.0;
 
         public Vector3d SegmentClosest;

--- a/distance/DistTriangle3Triangle3.cs
+++ b/distance/DistTriangle3Triangle3.cs
@@ -5,8 +5,9 @@ using System.Text;
 
 namespace g3
 {
-    public class DistTriangle3Triangle3
+    public struct DistTriangle3Triangle3
     {
+        // Inputs
         Triangle3d triangle0;
         public Triangle3d Triangle0
         {
@@ -21,6 +22,7 @@ namespace g3
             set { triangle1 = value; DistanceSquared = -1.0; }
         }
 
+        // Outputs
         public double DistanceSquared = -1.0;
 
         public Vector3d Triangle0Closest;

--- a/queries/MeshQueries.cs
+++ b/queries/MeshQueries.cs
@@ -14,7 +14,7 @@ namespace g3
         public static DistPoint3Triangle3 TriangleDistance(DMesh3 mesh, int ti, Vector3d point)
         {
             if (!mesh.IsTriangle(ti))
-                return null;
+                return new DistPoint3Triangle3();
             Triangle3d tri = new Triangle3d();
             mesh.GetTriVertices(ti, ref tri.V0, ref tri.V1, ref tri.V2);
             DistPoint3Triangle3 q = new DistPoint3Triangle3(point, tri);
@@ -62,7 +62,7 @@ namespace g3
         public static DistTriangle3Triangle3 TriangleTriangleDistance(DMesh3 mesh1, int ti, DMesh3 mesh2, int tj, Func<Vector3d, Vector3d> TransformF = null)
         {
             if (mesh1.IsTriangle(ti) == false || mesh2.IsTriangle(tj) == false)
-                return null;
+                return new DistTriangle3Triangle3();
             Triangle3d tri1 = new Triangle3d(), tri2 = new Triangle3d();
             mesh1.GetTriVertices(ti, ref tri1.V0, ref tri1.V1, ref tri1.V2);
             mesh2.GetTriVertices(tj, ref tri2.V0, ref tri2.V1, ref tri2.V2);
@@ -120,7 +120,7 @@ namespace g3
         public static DistTriangle3Triangle3 TrianglesDistance(DMesh3 mesh1, int ti, DMesh3 mesh2, int tj, Func<Vector3d,Vector3d> TransformF = null)
         {
             if (mesh1.IsTriangle(ti) == false || mesh2.IsTriangle(tj) == false)
-                return null;
+                return new DistTriangle3Triangle3();
             Triangle3d tri1 = new Triangle3d(), tri2 = new Triangle3d();
             mesh1.GetTriVertices(ti, ref tri1.V0, ref tri1.V1, ref tri1.V2);
             mesh2.GetTriVertices(tj, ref tri2.V0, ref tri2.V1, ref tri2.V2);


### PR DESCRIPTION
Had some spare time, tried to handle a simple TODO item.

Classes within /distance converted to struct, aside from static Distance. Considering adding an Obsolete attribute to it?

MeshQueries hit a snag: it returns null on lines 17, 65, and 123. Structs cannot be null and I *think* wrapping with nullable defeats purpose of switching to struct. For now, returning a new struct. 

Taking a guess on what you'd prefer to in the future for MeshQueries:
- returns ResultOrFail<DistPoint3Triangle3>
- out parameter: public static void TriangleDistance(DMesh3 mesh, int ti, Vector3d point, out DistPoint3Triangle3 value)
- Create an empty version of each struct
- output (bool success, DistPoint3Triangle3 result)
- int ti for triangle index becomes a struct that must be valid to be made. The mesh it is coming from would create it. This would move the failure closer to the start of the operation:
```
public struct TriangleId(int id);

public ResultOrFail<TriangleId> DMesh3.GetTriangleId(int index);
```