### PR TITLE
DistPoint2Circle2 GetSquared edited

### DIFF
--- a/distance/DistPoint2Circle2.cs
+++ b/distance/DistPoint2Circle2.cs
@@ -60,7 +60,8 @@ namespace g3
                 AllCirclePointsEquidistant = false;
             } else {
                 // All circle points are equidistant from P.  Return one of them.
-                CircleClosest = circle.Center + circle.Radius;
+                CircleClosest = circle.Center;
+                CircleClosest.x += circle.Radius;
                 AllCirclePointsEquidistant = true;
             }
 


### PR DESCRIPTION
As discussed.

Haven't edited this because I'm not sure ATM if it was also effected:

```
            Vector2d PmC = point - circle.Center;
            double lengthPmC = PmC.Length;
            if (lengthPmC > MathUtil.Epsilon) {
                CircleClosest = circle.Center + circle.Radius * PmC / lengthPmC;
                AllCirclePointsEquidistant = false;
            } 
```

Refs
#215 
#213 